### PR TITLE
Fix client options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,19 @@ Or install it yourself as:
 $ gem install omniauth-okta
 ```
 
-### Environment Variables
-
-```bash
-OKTA_CLIENT_ID     # required
-OKTA_CLIENT_SECRET # required
-OKTA_ORG           # required - defaults to 'your-org' if unset
-OKTA_DOMAIN        # optional - defaults to 'okta.com' if unset
-```
-
 ### OmniAuth
 
 Here's an example for adding the middleware to a Rails app in `config/initializers/omniauth.rb`:
 
 ```ruby
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :okta, ENV['OKTA_CLIENT_ID'], ENV['OKTA_CLIENT_SECRET']
+  provider :okta, ENV['OKTA_CLIENT_ID'], ENV['OKTA_CLIENT_SECRET'], {
+    client_options: {
+      site:           'https://your-org.okta.com',
+      authorize_url:  'https://your-org.okta.com/oauth2/v1/authorize',
+      token_url:      'https://your-org.okta.com/oauth2/v1/token'
+    }
+  }
 end
 ```
 
@@ -57,9 +54,14 @@ or add options like the following:
   config.omniauth(:okta,
                   ENV['OKTA_CLIENT_ID'],
                   ENV['OKTA_CLIENT_SECRET'],
-                  :scope => 'openid profile email',
-                  :fields => ['profile', 'email'],
-                  :strategy_class => OmniAuth::Strategies::Okta)
+                  scope: 'openid profile email',
+                  fields: ['profile', 'email'],
+                  client_options: {
+                    site:          'https://your-org.okta.com',
+                    authorize_url: 'https://your-org.okta.com/oauth2/v1/authorize',
+                    token_url:     'https://your-org.okta.com/oauth2/v1/token'
+                  },
+                  strategy_class: OmniAuth::Strategies::Okta)
 ```
 
 Then add the following to 'config/routes.rb' so the callback routes are defined.

--- a/lib/omniauth-okta/version.rb
+++ b/lib/omniauth-okta/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module Okta
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'.freeze
   end
 end

--- a/lib/omniauth/strategies/okta.rb
+++ b/lib/omniauth/strategies/okta.rb
@@ -5,24 +5,19 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class Okta < OmniAuth::Strategies::OAuth2
-
-      ORG           = ENV['OKTA_ORG']    || 'your-org'
-      DOMAIN        = ENV['OKTA_DOMAIN'] || 'okta'
-      BASE_URL      = "https://#{ORG}.#{DOMAIN}.com"
-      DEFAULT_SCOPE = %[openid profile email].freeze
+      DEFAULT_SCOPE = %{openid profile email}.freeze
 
       option :name, 'okta'
-
       option :skip_jwt, false
       option :jwt_leeway, 60
 
+      # These are defaults that need to be overriden on an implementation
       option :client_options, {
-        site:          BASE_URL,
-        authorize_url: "#{BASE_URL}/oauth2/v1/authorize",
-        token_url:     "#{BASE_URL}/oauth2/v1/token",
+        site:          'https://your-org.okta.com',
+        authorize_url: 'https://your-org.okta.com/oauth2/v1/authorize',
+        token_url:     'https://your-org.okta.com/oauth2/v1/token',
         response_type: 'id_token'
       }
-
       option :scope, DEFAULT_SCOPE
 
       uid { raw_info['sub'] }
@@ -38,37 +33,35 @@ module OmniAuth
       end
 
       extra do
-        hash = {}
-        hash[:raw_info] = raw_info unless skip_info?
-        hash[:id_token] = access_token.token
-        if !options[:skip_jwt] && !access_token.token.nil?
-          hash[:id_info] = validated_token(access_token.token)
+        {}.tap do |h|
+          h[:raw_info] = raw_info unless skip_info?
+
+          if access_token
+            h[:id_token] = access_token.token
+
+            if !options[:skip_jwt] && !access_token.token.nil?
+              h[:id_info] = validated_token(access_token.token)
+            end
+          end
         end
-        hash
       end
 
       alias :oauth2_access_token :access_token
 
       def access_token
-        ::OAuth2::AccessToken.new(client, oauth2_access_token.token, {
-          :refresh_token => oauth2_access_token.refresh_token,
-          :expires_in    => oauth2_access_token.expires_in,
-          :expires_at    => oauth2_access_token.expires_at
-        })
+        if oauth2_access_token
+          ::OAuth2::AccessToken.new(client, oauth2_access_token.token, {
+            refresh_token: oauth2_access_token.refresh_token,
+            expires_in:    oauth2_access_token.expires_in,
+            expires_at:    oauth2_access_token.expires_at
+          })
+        end
       end
 
       def raw_info
         @_raw_info ||= access_token.get('/oauth2/v1/userinfo').parsed || {}
       rescue ::Errno::ETIMEDOUT
         raise ::Timeout::Error
-      end
-
-      def request_phase
-        super
-      end
-
-      def callback_phase
-        super
       end
 
       def callback_url
@@ -80,16 +73,16 @@ module OmniAuth
                    nil,
                    false,
                    verify_iss:        true,
-                   iss:               BASE_URL,
+                   iss:               options[:client_options][:site],
                    verify_aud:        true,
-                   aud:               BASE_URL,
+                   aud:               options[:client_options][:site],
                    verify_sub:        true,
                    verify_expiration: true,
                    verify_not_before: true,
                    verify_iat:        true,
                    verify_jti:        false,
                    leeway:            options[:jwt_leeway]
-                   ).first
+        ).first
       end
     end
   end

--- a/omniauth-okta.gemspec
+++ b/omniauth-okta.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "bundler", "~> 1.5"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", "~> 2.7"
+  s.add_development_dependency "rspec", "~> 3"
   s.add_development_dependency "rack-test"
 end

--- a/omniauth-okta.gemspec
+++ b/omniauth-okta.gemspec
@@ -5,8 +5,8 @@ require "omniauth-okta/version"
 Gem::Specification.new do |s|
   s.name          = "omniauth-okta"
   s.version       = OmniAuth::Okta::VERSION
-  s.authors       = ["Dan Andrews"]
-  s.email         = ["daniel.raymond.andrews@gmail.com"]
+  s.authors       = ['Dan Andrews', 'Hector Rios']
+  s.email         = ['daniel.raymond.andrews@gmail.com', 'that.hector@gmail.com']
   s.homepage      = ""
   s.summary       = %q{Unofficial OmniAuth OAuth2 strategy for Okta}
   s.description   = %q{Unofficial OmniAuth OAuth2 strategy for Okta}

--- a/spec/omniauth/strategies/okta_spec.rb
+++ b/spec/omniauth/strategies/okta_spec.rb
@@ -70,9 +70,16 @@ describe OmniAuth::Strategies::Okta do
   describe 'extra' do
     before :each do
       allow(subject).to receive(:raw_info) { { :foo => 'bar' } }
+      allow(subject).to receive(:access_token)
+                          .and_return(
+                            instance_double(::OAuth2::AccessToken,
+                                            token:         nil,
+                                            refresh_token: 'token',
+                                            expires_in:    0,
+                                            expires_at:    0))
     end
 
-    it { expect(subject.extra['raw_info']).to eq({ :foo => 'bar' }) }
+    it { expect(subject.extra[:raw_info]).to eq({ :foo => 'bar' }) }
   end
 
   describe 'id_token' do


### PR DESCRIPTION
https://github.com/dandrews/omniauth-okta/pull/1

> - Removed the environment variables for setting up the urls, the code that is configuring the gem can do that if they want to.
> - Use the options[:client_options][:site] for iis and aud when validating the token instead of the environment variables
> - Updated readme

> If you need any other changes to be able to merge this let me know!

Also fixed the broken test